### PR TITLE
orderByはstringを受け付けるようにする

### DIFF
--- a/src/spearly-api-client/SpearlyApiClient.ts
+++ b/src/spearly-api-client/SpearlyApiClient.ts
@@ -12,7 +12,7 @@ export type GetParams = {
   offset?: number
   order?: 'desc' | 'asc'
   orderDirection?: 'desc' | 'asc'
-  orderBy?: 'latest' | 'popular'
+  orderBy?: string
   filterBy?: string
   filterValue?: string
   filterRef?: string


### PR DESCRIPTION
## 概要
orderByはstringを受け付けるようにする

## 理由
`popular` or `latest` のみでなく、任意のフィールドタイプの指定もできたため