### PR TITLE
SpearlyApiClient のコンストラクタパラメータ変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ $ yarn add @spearly/sdk-js
 ```js
 import { SpearlyApiClient } from '@spearly/sdk-js'
 
-const apiClient = new SpearlyApiClient(SPEARLY_DOMAIN, API_KEY)
+const apiClient = new SpearlyApiClient(API_KEY)
+```
+
+You can specify the API Server as well using by optional.
+
+```js
+import { SpearlyApiClient } from '@spearly/sdk-js'
+
+const apiClient = new SpearlyApiClient(API_KEY, API_SERVER_DOMAIN)
 ```
 
 ### Get Content Lists

--- a/src/spearly-api-client/SpearlyApiClient.ts
+++ b/src/spearly-api-client/SpearlyApiClient.ts
@@ -3,6 +3,8 @@ import { camelToSnake, recursiveToCamels } from '../utils'
 import { mapList, mapContent, mapForm, mapFormAnswer } from '../map'
 import { ServerList, ServerContent, ServerForm, ServerFormAnswer } from '../types'
 
+const BASE_URL_FALLBACK = 'api.spearly.com'
+
 export type BaseHeaders = {
   Accept: string
   Authorization: string
@@ -35,8 +37,8 @@ export class SpearlyApiClient {
     Authorization: '',
   }
 
-  constructor(domain: string, apiKey: string) {
-    this.baseURL = `https://${domain}`
+  constructor(apiKey: string, domain?: string) {
+    this.baseURL = `https://${domain || BASE_URL_FALLBACK}`
     this.baseHeaders.Accept = 'application/vnd.spearly.v2+json'
     this.baseHeaders.Authorization = `Bearer ${apiKey}`
   }

--- a/src/spec/spearly-api-client/SpearlyApiClient.spec.ts
+++ b/src/spec/spearly-api-client/SpearlyApiClient.spec.ts
@@ -158,7 +158,7 @@ describe('SpearlyApiClient', () => {
   let apiClient: SpearlyApiClient
 
   beforeEach(() => {
-    apiClient = new SpearlyApiClient('papi.spearly.app', 'API_KEY')
+    apiClient = new SpearlyApiClient('API_KEY', 'papi.spearly.app')
   })
 
   describe('APIへのアクセスポイント', () => {


### PR DESCRIPTION
#56 にある通り以下の修正をしています。


> 2. ドメインを オプション指定とする
> ```
> const apiClient = new SpearlyApiClient(API_KEY)
> ```
> - SPEARLY_DOMAIN -> SPEARLY_API_URL (Optional) : Spearly CMS のドキュメントからコピペできるフォーマットにしたい

お手すきの際に確認をお願いします 🙏🏼 