### PR TITLE
Add confirmation email and screen properties

### DIFF
--- a/src/map/mapForm.ts
+++ b/src/map/mapForm.ts
@@ -1,10 +1,30 @@
 import { Form, ServerForm } from '../types'
 
 export const mapForm = (form: ServerForm): Form => {
+  const {
+    confirmationEmailEnabled,
+    confirmationEmailName,
+    confirmationEmailDescription,
+    confirmationScreenBeforeSubmitEnabled,
+    backButtonLabel,
+    submitButtonLabel,
+    ...others
+  } = form
+
   return {
-    ...form,
+    ...others,
     startedAt: form.startedAt ? new Date(form.startedAt) : null,
     endedAt: form.endedAt ? new Date(form.endedAt) : null,
     createdAt: new Date(form.createdAt),
+    confirmationEmail: {
+      enabled: confirmationEmailEnabled,
+      name: confirmationEmailName,
+      description: confirmationEmailDescription,
+    },
+    confirmationScreen: {
+      enabled: confirmationScreenBeforeSubmitEnabled,
+      backButtonLabel: backButtonLabel || '',
+      submitButtonLabel: submitButtonLabel || '',
+    },
   }
 }

--- a/src/spec/spearly-api-client/SpearlyApiClient.spec.ts
+++ b/src/spec/spearly-api-client/SpearlyApiClient.spec.ts
@@ -96,6 +96,12 @@ const serverLatestForm = {
   name: '',
   description: '',
   thankYouMessage: '',
+  confirmationEmailEnabled: true,
+  confirmationEmailName: 'メールアドレス',
+  confirmationEmailDescription: '回答内容のコピーが送信されます。',
+  confirmationScreenBeforeSubmitEnabled: true,
+  backButtonLabel: '戻る',
+  submitButtonLabel: null,
   fields: [
     {
       identifier: 'name',
@@ -120,6 +126,16 @@ const latestForm = {
   name: '',
   description: '',
   thankYouMessage: '',
+  confirmationEmail: {
+    enabled: true,
+    name: 'メールアドレス',
+    description: '回答内容のコピーが送信されます。',
+  },
+  confirmationScreen: {
+    enabled: true,
+    backButtonLabel: '戻る',
+    submitButtonLabel: '',
+  },
   fields: [
     {
       identifier: 'name',

--- a/src/types/Form.ts
+++ b/src/types/Form.ts
@@ -12,10 +12,26 @@ export type Form = {
   publicUid: string
   startedAt: Date | null
   thankYouMessage: string
+  confirmationEmail: {
+    enabled: boolean
+    name: string
+    description: string
+  }
+  confirmationScreen: {
+    enabled: boolean
+    backButtonLabel: string
+    submitButtonLabel: string
+  }
 }
 
 export type ServerForm = {
   createdAt: string
   endedAt: string | null
   startedAt: string | null
+  confirmationEmailEnabled: boolean
+  confirmationEmailName: string
+  confirmationEmailDescription: string
+  confirmationScreenBeforeSubmitEnabled: boolean
+  backButtonLabel: string | null
+  submitButtonLabel: string | null
 } & Omit<Form, 'createdAt' | 'endedAt' | 'startedAt'>


### PR DESCRIPTION
## Related Spearly CMS features
- Feature to send confirmation email to form submitter
- Feature to display a screen confirming the contents of responses before form submission