### PR TITLE
エラー発生時に AxiosError をそのまま返す修正

### DIFF
--- a/src/spearly-api-client/SpearlyApiClient.ts
+++ b/src/spearly-api-client/SpearlyApiClient.ts
@@ -60,8 +60,6 @@ export class SpearlyApiClient {
       const response = await this.client.get(`${endpoint}${queries}`)
       return recursiveToCamels(response.data)
     } catch (error: any) {
-      if (error.data) throw error.data
-      if (error.response?.data) throw error.response.data
       return Promise.reject(error)
     }
   }
@@ -71,9 +69,7 @@ export class SpearlyApiClient {
       const response = await this.client.post(endpoint, params)
       return recursiveToCamels(response.data)
     } catch (error: any) {
-      if (error.data) throw error.data
-      if (error.response?.data) throw error.response.data
-      return Promise.reject(new Error(error))
+      return Promise.reject(error)
     }
   }
 


### PR DESCRIPTION
## 変更点

#76 で例外をそのまま送信するように修正しましたが、4xx 系のエラーでメッセージが含まれると例外とせずメッセージ本文を返していたため、帯域制限を超えた際のエラーなどが取得できていませんでした。  
この修正では、AxiosError が発生したらそのままエラーを投げるようにしています。

また、合わせて Post 時も同様の処理を加えています。