### PR TITLE
add 'select_box' to FormInputType

### DIFF
--- a/src/types/FormInputType.ts
+++ b/src/types/FormInputType.ts
@@ -1,1 +1,11 @@
-export type FormInputType = 'text' | 'number' | 'email' | 'tel' | 'url' | 'radio' | 'checkbox' | 'text_area' | 'file'
+export type FormInputType =
+  | 'text'
+  | 'number'
+  | 'email'
+  | 'tel'
+  | 'url'
+  | 'radio'
+  | 'checkbox'
+  | 'text_area'
+  | 'file'
+  | 'select_box'


### PR DESCRIPTION
## Overview
SDK JS to add `select_box` to Form Input Type, so SDK JS also support it.

## Change Description
- update `FormInputType` type