### PR TITLE
Fix: コンテンツ参照した場合の定義の変更 / Update content type field definition

### DIFF
--- a/src/spearly-api-client/SpearlyApiClient.ts
+++ b/src/spearly-api-client/SpearlyApiClient.ts
@@ -83,7 +83,10 @@ export class SpearlyApiClient {
   async getContent(contentTypeId: string, contentId: string, params: GetContentParams = {}) {
     params.distinctId = params.distinctId ? params.distinctId : this.analytics.distinctId
     const queries = this.toContentParams(params)
-    const response = await this.getRequest<{ data: ServerContent }>(`/content_types/${contentTypeId}/contents/${contentId}`, queries)
+    const response = await this.getRequest<{ data: ServerContent }>(
+      `/content_types/${contentTypeId}/contents/${contentId}`,
+      queries
+    )
     return mapContent(response.data)
   }
 

--- a/src/spec/spearly-api-client/SpearlyApiClient.spec.ts
+++ b/src/spec/spearly-api-client/SpearlyApiClient.spec.ts
@@ -254,7 +254,10 @@ describe('SpearlyApiClient', () => {
 
       it('APIレスポンスが正常系であればContentにマッピングされたデータが取得することができる', async () => {
         const res = await apiClient.getContent('content_type_id', 'content_id')
-        expect(spyRequest).toHaveBeenCalledWith('/content_types/content_type_id/contents/content_id', '?distinct_id=distinct_id')
+        expect(spyRequest).toHaveBeenCalledWith(
+          '/content_types/content_type_id/contents/content_id',
+          '?distinct_id=distinct_id'
+        )
         expect(res).toEqual(content)
       })
 
@@ -262,12 +265,18 @@ describe('SpearlyApiClient', () => {
         await apiClient.getContent('content_type_id', 'content_id', {
           patternName: 'b',
         })
-        expect(spyRequest).toHaveBeenCalledWith('/content_types/content_type_id/contents/content_id', '?distinct_id=distinct_id&pattern_name=b')
+        expect(spyRequest).toHaveBeenCalledWith(
+          '/content_types/content_type_id/contents/content_id',
+          '?distinct_id=distinct_id&pattern_name=b'
+        )
       })
 
       it('コンテンツタイプを指定してリクエストする', async () => {
         await apiClient.getContent('content_type_id', 'content_id', {})
-        expect(spyRequest).toHaveBeenCalledWith('/content_types/content_type_id/contents/content_id', '?distinct_id=distinct_id')
+        expect(spyRequest).toHaveBeenCalledWith(
+          '/content_types/content_type_id/contents/content_id',
+          '?distinct_id=distinct_id'
+        )
       })
     })
 

--- a/src/types/FieldType.ts
+++ b/src/types/FieldType.ts
@@ -1,3 +1,5 @@
+import { Content } from './Content'
+
 export type FieldInputType = 'text' | 'number' | 'rich_text' | 'image' | 'calendar' | 'map' | 'content_type' | 'tags'
 
 export type FieldType<T> = {
@@ -17,6 +19,10 @@ export type MapValue = {
   longitude: number
 }
 
+export type ContentTypeValue = {
+  data: Content
+}
+
 export type FieldTypeText = FieldType<string>
 
 export type FieldTypeNumber = FieldType<number>
@@ -31,17 +37,7 @@ export type FieldTypeMap = FieldType<MapValue>
 
 export type FieldTypeTags = FieldType<string[]>
 
-export type FieldTypeContentType = FieldType<
-  (
-    | FieldTypeText
-    | FieldTypeNumber
-    | FieldTypeRichText
-    | FieldTypeImage
-    | FieldTypeCalendar
-    | FieldTypeMap
-    | FieldTypeTags
-  )[]
->
+export type FieldTypeContentType = FieldType<ContentTypeValue>
 
 export type FieldTypeAll =
   | FieldTypeText


### PR DESCRIPTION
## 変更点

Spearly CMS で、コンテンツを参照した場合、以下のフィールドが得られました。

<details>
<summary> フィールドタイプの一部 </summary>

```
                      {
                            "id": "106286",
                            "type": "field",
                            "attributes": {
                                "pattern_name": "a",
                                "pattern_sync": true,
                                "value": {
                                    "data": [
                                        {
                                            "id": "11018",
                                            "type": "content",
                                            "attributes": {
                                                "content_alias": "refd",
                                                "public_uid": "c-24S6jxQlYWNL58rCybkz",
                                                "status": "published",
                                                "pattern_name": null,
                                                "published_at": "2023-07-24T14:47:00.000+09:00",
                                                "created_at": "2023-07-24T14:47:54.668+09:00",
                                                "updated_at": "2023-08-09T15:40:39.140+09:00",
                                                "fields": {
                                                    "data": [
                                                        {
                                                            "id": "106306",
                                                            "type": "field",
                                                            "attributes": {
                                                                "pattern_name": "a",
                                                                "pattern_sync": true,
                                                                "value": "参照されるコンテンツサンプル",
                                                                "input_type": "text",
                                                                "identifier": "text"
                                                            }
                                                        },
                                                        {
                                                            "id": "106307",
                                                            "type": "field",
                                                            "attributes": {
                                                                "pattern_name": "a",
                                                                "pattern_sync": true,
                                                                "value": "234",
                                                                "input_type": "number",
                                                                "identifier": "number"
                                                            }
                                                        }
                                                    ]
                                                },
                                                "previous_content": null,
                                                "next_content": null
                                            }
                                        }
                                    ]
                                },
                                "input_type": "content_type",
                                "identifier": "ref"
                            }
                        }
```
</details>

通常、コンテンツタイプ以外のデータにおいて、`value` に含まれるものは、Spearly CMS で設定した値が入っているようです。(地図フィールドタイプのときだけは、 本ライブラリの定義にある通り、`MapValue` が返ってきていました。)
```
{
    "id": "106306",
    "type": "field",
    "attributes": {
        "pattern_name": "a",
        "pattern_sync": true,
        "value": "参照されるコンテンツサンプル",
        "input_type": "text",
        "identifier": "text"
    }
},
```

今回のコンテンツタイプのケースでは、`value` にはコンテンツの配列が含まれているようなので、本ライブラリの定義を変更しています。

※公式のドキュメントでは、参照型のレスポンスに関する記述はありませんでした[1] が、埋め込み方法の説明ページ (`/content_types/xxxx/info/api` のサンプルレスポンスには、参照型は今回調べた内容と同じ値がが入ってくるようです。

https://docs.spearly.com/cms/reference#api-content-summary